### PR TITLE
configure: replace `which` command with `command -v`

### DIFF
--- a/configure
+++ b/configure
@@ -79,9 +79,9 @@ echo $ECHO_N "Finding Data file location ... $ECHO_C"
 datadir=`$ASPELL dump config data-dir`
 echo $datadir
 
-echo "ASPELL = `which $ASPELL`" > Makefile
+echo "ASPELL = `command -v $ASPELL`" > Makefile
 echo "ASPELL_FLAGS = $ASPELL_FLAGS" >> Makefile
-echo "PREZIP = `which $PREZIP`" >> Makefile
+echo "PREZIP = `command -v $PREZIP`" >> Makefile
 echo "DESTDIR = $DESTDIR" >> Makefile
 echo "dictdir = $dictdir" >> Makefile
 echo "datadir = $datadir" >> Makefile


### PR DESCRIPTION
The command `which` is not present in some
contexts, such as docker.
It is better to just use `command -v`, which is
builtin into the shell.

Fixes #3